### PR TITLE
Add space indentation handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ out
 node_modules
 typings
 test/sampleFiles/temp
+.vscode-test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 out
 node_modules
+typings
+test/sampleFiles/temp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+sudo: false
+
+language: node_js
+node_js:
+  - "6"
+
+os:
+  - osx
+  - linux
+
+before_install:
+  - if [ $TRAVIS_OS_NAME == "linux" ]; then
+      export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
+      sh -e /etc/init.d/xvfb start;
+      sleep 3;
+    fi
+
+install:
+  - npm install
+  - npm run vscode:prepublish
+
+script:
+  - npm run test:LinuxAndOSX

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,17 @@
 			"sourceMaps": true,
 			"outDir": "${workspaceRoot}/",
 			"preLaunchTask": "npm"
+		},
+		{
+			"name": "Launch Tests",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
+			"stopOnEntry": false,
+			"sourceMaps": true,
+			"outDir": "${workspaceRoot}/out/test",
+			"preLaunchTask": "npm"
 		}
 	]
 }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Download it now https://marketplace.visualstudio.com/items/bradgashler.htmltagwr
 Select a block of text or a string of text.  Press <kbd>Alt</kbd> + <kbd>W</kbd> or <kbd>Option</kbd> + <kbd>W</kbd> for Mac.  Type the tag name you want, and it will populate the beginning and end tag automatically.
 
 ##Known Issues
-It works only with code using tab formatting.  It won't currently play nice with spaces, if that's how you roll.  I would like to address this in the future.  Feel free to submit a pull request if you beat me to it.
+It will not always work as expected in files with mixed space/tab indentation.
 
 ##Report Issues
 I welcome pull requests.  Please report an issue on GitHub if you have trouble.  We haven't tested this on Mac yet.

--- a/package.json
+++ b/package.json
@@ -30,11 +30,15 @@
 	"scripts": {
 		"vscode:prepublish": "node ./node_modules/vscode/bin/compile",
         "compile": "node ./node_modules/vscode/bin/compile -watch -p ./",
-		"postinstall": "node ./node_modules/vscode/bin/install"
+		"postinstall": "typings install && node ./node_modules/vscode/bin/install",
+		"typings": "typings"
 	},
 	"devDependencies": {
-		"vscode": "0.11.x",
-		"typescript": "^1.8.5"
+		"chai": "*",
+		"fs-extra": "^0.30.0",
+		"typescript": "^1.8.5",
+		"typings": "*",
+		"vscode": "0.11.x"
 	},
 	"icon":"images/htmlTagWrap_icon.svg",
 	"galleryBanner": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
 		"vscode:prepublish": "node ./node_modules/vscode/bin/compile",
         "compile": "node ./node_modules/vscode/bin/compile -watch -p ./",
 		"postinstall": "typings install && node ./node_modules/vscode/bin/install",
-		"typings": "typings"
+		"typings": "typings",
+		"test:LinuxAndOSX": "node ./node_modules/vscode/bin/test"
 	},
 	"devDependencies": {
 		"chai": "*",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ function getTabString(editor: vscode.TextEditor): string {
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
-export function activate() { 
+export function activate() {
 
 	// Use the console to output diagnostic information (console.log) and errors (console.error)
 	// This line of code will only be executed once when your extension is activated
@@ -28,84 +28,61 @@ export function activate() {
 
 		var editor = vscode.window.activeTextEditor;
 		if (editor != undefined) {
-			
 			console.log('Window has been got');
-			
+
 			var selection = editor.selection;
 			var selectedText = editor.document.getText(selection);
-			
+
 			var firstIndex = 1;
 			var lastIndex = selectedText.length;
-			
+
 			console.log('selection is: ' + selectedText);
 			console.log('length is: ' + lastIndex);
 			console.log('selection.start.character: ' + selection.start.character);
 			console.log('selection.end.character: ' + selection.end.character);
-			
+
 			var selectionStart = selection.start;
 			var selectionEnd = selection.end;
-			
+
 			if (selectionEnd.line > selectionStart.line) {
 				//Wrap it as a block
 				var lineAbove = selectionStart.line - 1;
 				var lineBelow = selectionEnd.line + 1;
-				
+
 				//console.log('tabSize = ' + tabSize);
 				let tabSizeSpace = getTabString(editor);
 				var selectionStart_spaces = editor.document.lineAt(selectionStart.line).text.substring(0, selectionStart.character);
-				
+				//console.log('selectionStart_spaces = ' + selectionStart_spaces);
 				//console.log('tabsizeSpace =' + tabSizeSpace);
-				
+
 				editor.edit((editBuilder) => {
-					
-					//last line
-					for (var i = selectionEnd.line; i >= selectionStart.line; i--) {
-						var _lineNumber = i;
-						
-						if (_lineNumber === selectionEnd.line) {
-							editBuilder.insert(new vscode.Position(_lineNumber, selectionEnd.character), '\n' + selectionStart_spaces + '</p>');
-							editBuilder.insert(new vscode.Position(_lineNumber, 0), tabSizeSpace);
-							console.log('End line done.  Line #: ' + _lineNumber);
-						}
-						else if (_lineNumber === selectionStart.line) {
-							editBuilder.insert(new vscode.Position(_lineNumber, selectionStart.character), '<p>\n' + selectionStart_spaces + tabSizeSpace);
-							console.log('Start Line done.  Line #: ' + _lineNumber);
-							console.log('selectionStart_spaces = ' + selectionStart_spaces);
-						}
-						else {
-							console.log('FOR Loop line #: ' + _lineNumber);
-							editBuilder.insert(new vscode.Position(_lineNumber, 0), tabSizeSpace);
-						}
-						
+					// Modify last line of selection
+					editBuilder.insert(new vscode.Position(selectionEnd.line, selectionEnd.character), '\n' + selectionStart_spaces + '</p>');
+					editBuilder.insert(new vscode.Position(selectionEnd.line, 0), tabSizeSpace);
+					console.log('End line done.  Line #: ' + selectionEnd.line);
+
+					for (let lineNumber = selectionEnd.line - 1; lineNumber > selectionStart.line; lineNumber--) {
+						console.log('FOR Loop line #: ' + lineNumber);
+						editBuilder.insert(new vscode.Position(lineNumber, 0), tabSizeSpace);
 					}
-					
-					//
-					
-					//
-					
-				/*
-				*	.then() => {}  is called a lambda funciton.  It's in multiple programming language, new to ECMAScript6.
-				*	It's like saying then(function(x));
-				*
-				*/					
+
+					// Modify firs line of selection
+					editBuilder.insert(new vscode.Position(selectionStart.line, selectionStart.character), '<p>\n' + selectionStart_spaces + tabSizeSpace);
+					console.log('Start Line done.  Line #: ' + selectionStart.line);
 				}).then(() => {
 					console.log('Edit applied!');
-					
+
 					var bottomTagLine = lineBelow + 1;
 					var firstTagSelectionSelection: vscode.Selection = new vscode.Selection(selectionStart.line, selectionStart.character + 1, selectionStart.line, selectionStart.character + 2);
 					var lastTagSelectionSelection: vscode.Selection = new vscode.Selection(bottomTagLine, selectionStart.character + 2, bottomTagLine, selectionStart.character + 3);
 					var tagSelections: vscode.Selection[] = [firstTagSelectionSelection, lastTagSelectionSelection];
-					
+
 					editor.selections = tagSelections;
 				}, (err) => {
 					console.log('Edit rejected!');
 					console.error(err);
 				});
-				
-							
 			}
-			
-			
 			else {
 				//Wrap it inline
 				editor.edit((editBuilder) => {
@@ -113,20 +90,17 @@ export function activate() {
 						editBuilder.insert(new vscode.Position(selectionEnd.line, selectionStart.character), '<p>');
 					}).then(() => {
 						console.log('Edit applied!');
-						
+
 						var firstTagSelectionSelection: vscode.Selection = new vscode.Selection(selectionStart.line, selectionStart.character + 1, selectionStart.line, selectionStart.character + 2);
 						var lastTagSelectionSelection: vscode.Selection = new vscode.Selection(selectionEnd.line, selectionEnd.character + 3 + 2, selectionEnd.line, selectionEnd.character + 3 + 3);
 						var tagSelections: vscode.Selection[] = [firstTagSelectionSelection, lastTagSelectionSelection];
-						
+
 						editor.selections = tagSelections;
 					}, (err) => {
 						console.log('Edit rejected!');
 						console.error(err);
-					});				
+					});
 			}
-			
-				
 		};
-		
 	});
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,16 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
-import * as vscode from 'vscode'; 
+import * as vscode from 'vscode';
+
+function getTabString(editor: vscode.TextEditor): string {
+	let spacesUsed = <boolean>editor.options.insertSpaces;
+	if (spacesUsed) {
+		let numOfUsedSpaces = <number>editor.options.tabSize;
+		return ' '.repeat(numOfUsedSpaces);
+	}
+
+	return '\t';
+}
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -40,20 +50,20 @@ export function activate() {
 				var lineAbove = selectionStart.line - 1;
 				var lineBelow = selectionEnd.line + 1;
 				
-				let tabSize = editor.options.tabSize;
 				//console.log('tabSize = ' + tabSize);
-				let tabSizeSpace = '\t';
-				var selectionStart_spaces = Array(selectionStart.character + 1).join('\t');
+				let tabSizeSpace = getTabString(editor);
+				var selectionStart_spaces = editor.document.lineAt(selectionStart.line).text.substring(0, selectionStart.character);
 				
 				//console.log('tabsizeSpace =' + tabSizeSpace);
 				
 				editor.edit((editBuilder) => {
 					
+					//last line
 					for (var i = selectionEnd.line; i >= selectionStart.line; i--) {
 						var _lineNumber = i;
 						
 						if (_lineNumber === selectionEnd.line) {
-							editBuilder.insert(new vscode.Position(_lineNumber, selectionEnd.character), '\n' + selectionStart_spaces + '</p>' + tabSizeSpace);
+							editBuilder.insert(new vscode.Position(_lineNumber, selectionEnd.character), '\n' + selectionStart_spaces + '</p>');
 							editBuilder.insert(new vscode.Position(_lineNumber, 0), tabSizeSpace);
 							console.log('End line done.  Line #: ' + _lineNumber);
 						}

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -33,6 +33,8 @@ function parametrizedTest(startFilePath: string, expectedResultFilePath: string,
 			return workspace.openTextDocument(samplesFolder + expectedResultFilePath);
 		}).then((expectedResultDocument) => {
 			expectedResult = expectedResultDocument.getText();
+		}).then(()=> {
+			return commands.executeCommand('workbench.action.closeActiveEditor').then(() => new Promise((f) => setTimeout(f, 500)));
 		});
 
 		return testPromise.then(() => {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -1,0 +1,60 @@
+//
+// Note: This example test is leveraging the Mocha test framework.
+// Please refer to their documentation on https://mochajs.org/ for help.
+//
+
+import {expect} from 'chai';
+import {workspace, window, Selection, Position, commands, extensions, Uri, TextEditor, Range} from 'vscode';
+import {copySync, CopyOptions, emptyDir} from 'fs-extra';
+import * as extension from '../src/extension';
+
+extension.activate();
+let extensionID = 'bradgashler.htmltagwrap';
+let samplesFolder = extensions.getExtension(extensionID).extensionPath + '/test/sampleFiles/';
+let tempFolder = samplesFolder + 'temp/';
+
+function parametrizedTest(startFilePath: string, expectedResultFilePath: string, selectionStart: Position, selectionEnd: Position, failMessage: string) {
+		let result: string;
+		let expectedResult: string;
+		let editor: TextEditor;
+		let workingFilePath = tempFolder + startFilePath;
+		copySync(samplesFolder + startFilePath, workingFilePath, {clobber: true});
+
+		let testPromise = workspace.openTextDocument(workingFilePath).then((workingDocument) => {
+			return window.showTextDocument(workingDocument);
+		}).then((_editor) => {
+			editor = _editor;
+		}).then(() => {
+			editor.selection = new Selection(selectionStart, selectionEnd);
+			return commands.executeCommand('extension.htmlTagWrap').then(() => new Promise((f) => setTimeout(f, 500)));
+		}).then(() => {
+			result = editor.document.getText();
+		}).then(() => {
+			return workspace.openTextDocument(samplesFolder + expectedResultFilePath);
+		}).then((expectedResultDocument) => {
+			expectedResult = expectedResultDocument.getText();
+		});
+
+		return testPromise.then(() => {
+			expect(result).not.to.be.equal(undefined, 'File loding error');
+			expect(expectedResult).not.to.be.equal(undefined, 'File loding error');
+			expect(result).to.be.equal(expectedResult, failMessage);
+		});
+}
+
+
+suite('Extension Tests', function() {
+	test('HTML with tabs block wrap test', function() {
+		return parametrizedTest('tabFile.html', 'expectedTabBlockWrapFileResult.html', new Position(1, 1), new Position(6, 6), 'Tab using block wrap does not work');
+	});
+	test('HTML with spaces block wrap test', function() {
+		return parametrizedTest('spaceFile.html', 'expectedSpaceBlockWrapFileResult.html', new Position(1, 4), new Position(7, 9), 'Space using block wrap does not work');
+	});
+	test('HTML with tabs line wrap test', function() {
+		return parametrizedTest('tabFile.html', 'expectedTabLineWrapFileResult.html', new Position(2, 2), new Position(2, 11), 'Tab using line wrap does not work');
+	});
+	test('HTML with spaces line wrap test', function() {
+		return parametrizedTest('spaceFile.html', 'expectedSpaceLineWrapFileResult.html', new Position(2, 8), new Position(2, 17), 'Space using line wrap does not work');
+	});
+	teardown((done) => emptyDir(tempFolder, done));
+});

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,0 +1,23 @@
+//
+// PLEASE DO NOT MODIFY / DELETE UNLESS YOU KNOW WHAT YOU ARE DOING
+//
+// This file is providing the test runner to use when running extension tests.
+// By default the test runner in use is Mocha based.
+//
+// You can provide your own test runner if you want to override it by exporting
+// a function run(testRoot: string, clb: (error:Error) => void) that the extension
+// host can call to run the tests. The test runner is expected to use console.log
+// to report the results back to the caller. When the tests are finished, return
+// a possible error to the callback or null if none.
+
+var testRunner = require('vscode/lib/testrunner');
+
+// You can directly control Mocha options by uncommenting the following lines
+// See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
+testRunner.configure({
+	ui: 'tdd', 		// the TDD UI is being used in extension.test.ts (suite, test, etc.)
+	useColors: true, // colored output from test results
+	timeout: 10000
+});
+
+module.exports = testRunner;

--- a/test/sampleFiles/expectedSpaceBlockWrapFileResult.html
+++ b/test/sampleFiles/expectedSpaceBlockWrapFileResult.html
@@ -1,0 +1,11 @@
+<div>
+    <p>
+        <ul>
+            <li></li>
+            <li></li>
+            <li></li>
+            <li></li>
+            <li></li>
+        </ul>
+    </p>
+</div>

--- a/test/sampleFiles/expectedSpaceLineWrapFileResult.html
+++ b/test/sampleFiles/expectedSpaceLineWrapFileResult.html
@@ -1,0 +1,9 @@
+<div>
+    <ul>
+        <p><li></li></p>
+        <li></li>
+        <li></li>
+        <li></li>
+        <li></li>
+    </ul>
+</div>

--- a/test/sampleFiles/expectedTabBlockWrapFileResult.html
+++ b/test/sampleFiles/expectedTabBlockWrapFileResult.html
@@ -1,0 +1,10 @@
+<div>
+	<p>
+		<ul>
+			<li></li>
+			<li></li>
+			<li></li>
+			<li></li>
+		</ul>
+	</p>
+</div>

--- a/test/sampleFiles/expectedTabLineWrapFileResult.html
+++ b/test/sampleFiles/expectedTabLineWrapFileResult.html
@@ -1,0 +1,8 @@
+<div>
+	<ul>
+		<p><li></li></p>
+		<li></li>
+		<li></li>
+		<li></li>
+	</ul>
+</div>

--- a/test/sampleFiles/spaceFile.html
+++ b/test/sampleFiles/spaceFile.html
@@ -1,0 +1,9 @@
+<div>
+    <ul>
+        <li></li>
+        <li></li>
+        <li></li>
+        <li></li>
+        <li></li>
+    </ul>
+</div>

--- a/test/sampleFiles/tabFile.html
+++ b/test/sampleFiles/tabFile.html
@@ -1,0 +1,8 @@
+<div>
+	<ul>
+		<li></li>
+		<li></li>
+		<li></li>
+		<li></li>
+	</ul>
+</div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
 		"sourceMap": true
 	},
 	"exclude": [
-		"node_modules"
+		"node_modules",
+		".vscode-test"
 	]
 }

--- a/typings.json
+++ b/typings.json
@@ -1,0 +1,8 @@
+{
+  "devDependencies": {
+    "chai": "registry:npm/chai#3.5.0+20160415060238"
+  },
+  "globalDevDependencies": {
+    "fs-extra": "registry:dt/fs-extra#0.0.0+20160319124112"
+  }
+}


### PR DESCRIPTION
Fixes #2.

I divided the PR into 4 commits to make it easy to take part/s of it in case you don't like it as a whole. I can squash the commits into one if they're too granular for you.
## Changes:
- Modified extension.ts to handle spaces based indention (1edf329) 
- Simplified the working loop of block wrapping by moving handling of last and first row outside the loop (c2f657c)
- Removed some of the comments and trailing whitespaces (c2f657c)
- Added end to end tests for spaces/tabs block/line (a68c2f8)
- Added dependency on chai and fs-extra in tests (a68c2f8)
- Added typings usage - config file, updated npm scripts (a68c2f8)
